### PR TITLE
Remove extra colon from 2fa prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Using our `sample-target-allocations.csv` as above, a sample run could look as f
 $ ws-rebalancer rebalance -t sample-target-allocations.csv --email test@gmail.com --2fa
 Password:
 Repeat for confirmation:
-Enter 2FA code: : 12345
+Enter 2FA code: 12345
 0. non-registered
 Please input the account you want: 0
 Buy 5X MSFT @ 10.00 - New allocation 40.00%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ws-rebalancer"
-version = "1.0.0"
+version = "1.0.1"
 description = "A CLI tool that helps you rebalance your WealthSimple portfolios."
 license = "MIT"
 readme = "README.md"

--- a/ws_rebalancer/wealthsimple_login.py
+++ b/ws_rebalancer/wealthsimple_login.py
@@ -21,5 +21,5 @@ class WealthSimpleLogin(wealthsimple.WSTrade):
         MFACode = ""
         while not MFACode:
             # Obtain user input and ensure it is not empty
-            MFACode = click.prompt("Enter 2FA code: ")
+            MFACode = click.prompt("Enter 2FA code")
         return MFACode


### PR DESCRIPTION
The 2FA prompt was returning double colons instead of just 1. Fixed the
prompt so that it looks correct.